### PR TITLE
Update SDK to 5.15-21.08

### DIFF
--- a/org.fcitx.Fcitx5.Addon.ChineseAddons.yaml
+++ b/org.fcitx.Fcitx5.Addon.ChineseAddons.yaml
@@ -2,7 +2,7 @@ app-id: org.fcitx.Fcitx5.Addon.ChineseAddons
 branch: stable
 runtime: org.fcitx.Fcitx5
 runtime-version: stable
-sdk: org.kde.Sdk//5.15
+sdk: org.kde.Sdk//5.15-21.08
 build-extension: true
 appstream-compose: false
 separate-locales: false


### PR DESCRIPTION
The 5.15 version of the KDE Runtime is based on the 20.08 version of the Freedesktop Runtime and will stay as-is to keep compatibility.
The 5.15-21.08 version of the KDE Runtime is based on the 21.08 Freedesktop one. The Qt/KDE Libraries are mostyl similar between the two runtimes.

This change is mostly maintenance to keep the base runtime updated.